### PR TITLE
changed so all options (specifically rollout policy) can be given to solver

### DIFF
--- a/src/policies.jl
+++ b/src/policies.jl
@@ -2,17 +2,19 @@ type RandomPolicy <: Policy
     mdp::POMDP # contains the model
     rng::AbstractRNG
     action_space::AbstractSpace
-    action::Action
 end
 # constructor
 function RandomPolicy(mdp::POMDP, rng::AbstractRNG)
     as = actions(mdp)
-    a = create_action(mdp)
-    return RandomPolicy(mdp, rng, as, a)
+    return RandomPolicy(mdp, rng, as)
 end
 
-
-function POMDPs.action(policy::RandomPolicy, state::State)
+function POMDPs.action(policy::RandomPolicy, state::State, a::Action=create_action(policy.mdp))
     action_space = actions(policy.mdp, state, policy.action_space)
-    return rand!(policy.rng, policy.action, policy.action_space)
+    return rand!(policy.rng, a, policy.action_space)
 end
+
+# a placeholder for using in a RandomPolicy when the model hasn't been assigned yet
+type ModelNotAvailable <: POMDP end
+type BlankSpace <: AbstractSpace end
+POMDPs.actions(mdp::ModelNotAvailable) = BlankSpace()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,7 @@ ec = 3.0
 solver = MCTSSolver(n_iterations=n_iter, depth=depth, exploration_constant=ec)
 mdp = GridWorld()
 
-policy = MCTSPolicy(solver, mdp)
-
-policy = solve(solver, mdp, policy)
+policy = solve(solver, mdp)
 
 state = GridWorldState(1,1)
 


### PR DESCRIPTION
Max, see if this is ok with you. I think it's important to be able to specify all the options to the solver and then create a policy appropriate for the mdp with solve(solver, mdp)
