### PR TITLE
changed so all options (specifically rollout policy) can be given to solver

### DIFF
--- a/src/policies.jl
+++ b/src/policies.jl
@@ -2,17 +2,19 @@ type RandomPolicy <: Policy
     mdp::POMDP # contains the model
     rng::AbstractRNG
     action_space::AbstractSpace
-    action::Action
 end
 # constructor
 function RandomPolicy(mdp::POMDP, rng::AbstractRNG)
     as = actions(mdp)
-    a = create_action(mdp)
-    return RandomPolicy(mdp, rng, as, a)
+    return RandomPolicy(mdp, rng, as)
 end
 
-
-function POMDPs.action(policy::RandomPolicy, state::State)
+function POMDPs.action(policy::RandomPolicy, state::State, a::Action=create_action(policy.mdp))
     action_space = actions(policy.mdp, state, policy.action_space)
-    return rand!(policy.rng, policy.action, policy.action_space)
+    return rand!(policy.rng, a, policy.action_space)
 end
+
+# a placeholder for using in a RandomPolicy when the model hasn't been assigned yet
+type ModelNotAvailable <: POMDP end
+type BlankSpace <: AbstractSpace end
+POMDPs.actions(mdp::ModelNotAvailable) = BlankSpace()

--- a/src/policies.jl
+++ b/src/policies.jl
@@ -14,7 +14,10 @@ function POMDPs.action(policy::RandomPolicy, state::State, a::Action=create_acti
     return rand!(policy.rng, a, policy.action_space)
 end
 
-# a placeholder for using in a RandomPolicy when the model hasn't been assigned yet
-type ModelNotAvailable <: POMDP end
-type BlankSpace <: AbstractSpace end
-POMDPs.actions(mdp::ModelNotAvailable) = BlankSpace()
+type RandomSolver <: Solver
+    rng::AbstractRNG
+end
+
+function POMDPs.solve(solver::RandomSolver, mdp::POMDP)
+    return RandomPolicy(mdp, solver.rng)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,7 @@ ec = 3.0
 solver = MCTSSolver(n_iterations=n_iter, depth=depth, exploration_constant=ec)
 mdp = GridWorld()
 
-policy = MCTSPolicy(solver, mdp)
-
-policy = solve(solver, mdp, policy)
+policy = solve(solver, mdp)
 
 state = GridWorldState(1,1)
 


### PR DESCRIPTION
MCTSSolver now has a member called rollout_solver, which can be a solver or a policy. If it is a solver, when solve() is called on the MCTSSolver, solve() is also called on the rollout_solver to produce the rollout_policy. If it is a policy, then that policy is used directly as the rollout_policy

This was done so that all options can be specified to the solver (rather than only being able to specify rollout_policy to the policy), and so that the default behavior can be set to a random rollout in a sensible way.

Max, let me know if you think this is ok, and merge it.
