### PR TITLE
Add new method for action

### DIFF
--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -123,6 +123,10 @@ function POMDPs.action(policy::AbstractMCTSPolicy, state)
     # use map to conver index to mdp action
     return best.action
 end
+# new-definition of action for use with RolloutSimulator in POMDPToolbox
+function POMDPs.action(policy::AbstractMCTSPolicy, state, action)
+  POMDPs.action(policy, state)
+end
 
 # runs a simulation from the passed in state to the specified depth
 function simulate(policy::AbstractMCTSPolicy, state, depth::Int64)


### PR DESCRIPTION
action(policy,state,action) for use with RolloutSimulator in POMDPToolbox
This method was not defined before. Another option would have been to modify the call in POMDPToolbox/src/simulators/Rollout.jl : 
action(policy,state) instead of action(policy,state,action) (as it is implemented in the POMDPToolbox/src/simulators/HistoryRecorder.jl simulator). 
Tell me if this second option is better. 
