### PR TITLE
Use of ProgressMeter.jl and added a `reset_callback` to DPWSolver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 CPUTime = "1"
-Colors = "0.12"
+Colors = "0.11"
 D3Trees = "0.3"
 POMDPLinter = "0.1"
 POMDPModelTools = "0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 CPUTime = "1"
-Colors = "0.11"
+Colors = "0.11, 0.12"
 D3Trees = "0.3"
 POMDPLinter = "0.1"
 POMDPModelTools = "0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ POMDPPolicies = "182e52fb-cfd0-5e46-8c26-fd0667c990f4"
 POMDPSimulators = "e0d0a172-29c6-5d4e-96d0-f262df5d01fd"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/src/MCTS.jl
+++ b/src/MCTS.jl
@@ -8,6 +8,7 @@ using POMDPSimulators
 using CPUTime
 using Random
 using Printf
+using ProgressMeter
 
 export
     MCTSSolver,

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -56,7 +56,7 @@ function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false, show_
                 break
             end
         end
-        if !isnothing(p.solver.reset_callback)
+        if p.solver.reset_callback !== nothing
             p.solver.reset_callback(p.mdp, s) # Optional: used to reset/reinitialize MDP to a given state.
         end
         info[:search_time_us] = CPUtime_us() - start_us
@@ -93,7 +93,7 @@ function simulate(dpw::DPWPlanner, snode::Int, d::Int)
     sol = dpw.solver
     tree = dpw.tree
     s = tree.s_labels[snode]
-    if !isnothing(sol.reset_callback)
+    if sol.reset_callback !== nothing
         sol.reset_callback(dpw.mdp, s) # Optional: used to reset/reinitialize MDP to a given state.
     end
     if isterminal(dpw.mdp, s)

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -47,11 +47,13 @@ function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false, show_
             snode = insert_state_node!(tree, s, p.solver.check_repeat_state)
         end
 
+        show_progress ? progress = Progress(p.solver.n_iterations) : nothing
         nquery = 0
         start_us = CPUtime_us()
-        @showprogress dt for i = 1:p.solver.n_iterations
+        for i = 1:p.solver.n_iterations
             nquery += 1
             simulate(p, snode, p.solver.depth) # (not 100% sure we need to make a copy of the state here)
+            show_progress ? next!(progress) : nothing
             if CPUtime_us() - start_us >= p.solver.max_time * 1e6
                 break
             end

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -55,6 +55,9 @@ function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false)
                 break
             end
         end
+        if !isnothing(p.solver.reset_callback)
+            p.solver.reset_callback(p.mdp, s) # Optional: used to reset/reinitialize MDP to a given state.
+        end
         info[:search_time_us] = CPUtime_us() - start_us
         info[:tree_queries] = nquery
         if p.solver.tree_in_info || tree_in_info
@@ -89,6 +92,9 @@ function simulate(dpw::DPWPlanner, snode::Int, d::Int)
     sol = dpw.solver
     tree = dpw.tree
     s = tree.s_labels[snode]
+    if !isnothing(sol.reset_callback)
+        sol.reset_callback(dpw.mdp, s) # Optional: used to reset/reinitialize MDP to a given state.
+    end
     if isterminal(dpw.mdp, s)
         return 0.0
     elseif d == 0

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -18,7 +18,6 @@ Construct an MCTSDPW tree and choose the best action. Also output some informati
 function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false, show_progress=false)
     local a::actiontype(p.mdp)
     info = Dict{Symbol, Any}()
-    dt = show_progress ? 0.1 : Inf
     try
         if isterminal(p.mdp, s)
             error("""

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -59,7 +59,7 @@ function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false, show_
             end
         end
         if p.solver.reset_callback !== nothing
-            p.solver.reset_callback(p.mdp, s) # Optional: used to reset/reinitialize MDP to a given state.
+            p.solver.reset_callback(p.mdp, s) # Optional: leave the MDP in the current state.
         end
         info[:search_time_us] = CPUtime_us() - start_us
         info[:tree_queries] = nquery

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -48,7 +48,7 @@ function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false)
 
         nquery = 0
         start_us = CPUtime_us()
-        for i = 1:p.solver.n_iterations
+        @showprogress for i = 1:p.solver.n_iterations
             nquery += 1
             simulate(p, snode, p.solver.depth) # (not 100% sure we need to make a copy of the state here)
             if CPUtime_us() - start_us >= p.solver.max_time * 1e6

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -15,9 +15,10 @@ POMDPs.action(p::DPWPlanner, s) = first(action_info(p, s))
 """
 Construct an MCTSDPW tree and choose the best action. Also output some information.
 """
-function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false)
+function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false, show_progress=false)
     local a::actiontype(p.mdp)
     info = Dict{Symbol, Any}()
+    dt = show_progress ? 0.1 : Inf
     try
         if isterminal(p.mdp, s)
             error("""
@@ -48,7 +49,7 @@ function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false)
 
         nquery = 0
         start_us = CPUtime_us()
-        @showprogress for i = 1:p.solver.n_iterations
+        @showprogress dt for i = 1:p.solver.n_iterations
             nquery += 1
             simulate(p, snode, p.solver.depth) # (not 100% sure we need to make a copy of the state here)
             if CPUtime_us() - start_us >= p.solver.max_time * 1e6

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -142,7 +142,7 @@ function simulate(dpw::DPWPlanner, snode::Int, d::Int)
 
     # state progressive widening
     new_node = false
-    if tree.n_a_children[sanode] <= sol.k_state*tree.n[sanode]^sol.alpha_state
+    if (dpw.solver.enable_state_pw && tree.n_a_children[sanode] <= sol.k_state*tree.n[sanode]^sol.alpha_state) || tree.n_a_children[sanode] == 0
         sp, r = gen(DDNOut(:sp, :r), dpw.mdp, s, a, dpw.rng)
 
         if sol.check_repeat_state && haskey(tree.s_lookup, sp)

--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -58,7 +58,7 @@ function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false)
                 break
             end
         end
-        p.solver.reset_callback(p.mdp, s) # Optional: leave the MDP in the current state.
+        p.reset_callback(p.mdp, s) # Optional: leave the MDP in the current state.
         info[:search_time_us] = CPUtime_us() - start_us
         info[:tree_queries] = nquery
         if p.solver.tree_in_info || tree_in_info
@@ -93,7 +93,7 @@ function simulate(dpw::DPWPlanner, snode::Int, d::Int)
     sol = dpw.solver
     tree = dpw.tree
     s = tree.s_labels[snode]
-    sol.reset_callback(dpw.mdp, s) # Optional: used to reset/reinitialize MDP to a given state.
+    dpw.reset_callback(dpw.mdp, s) # Optional: used to reset/reinitialize MDP to a given state.
     if isterminal(dpw.mdp, s)
         return 0.0
     elseif d == 0

--- a/src/dpw_types.jl
+++ b/src/dpw_types.jl
@@ -36,6 +36,10 @@ Fields:
         If true, enable progressive widening on the action space; if false just use the whole action space.
         default: true
 
+    enable_state_pw::Bool
+        If true, enable progressive widening on the state space; if false just use the single next state (for deterministic problems).
+        default: true
+
     check_repeat_state::Bool
     check_repeat_action::Bool
         When constructing the tree, check whether a state or action has been seen before (there is a computational cost to maintaining the dictionaries necessary for this)
@@ -94,6 +98,7 @@ mutable struct DPWSolver <: AbstractMCTSSolver
     alpha_state::Float64
     keep_tree::Bool
     enable_action_pw::Bool
+    enable_state_pw::Bool
     check_repeat_state::Bool
     check_repeat_action::Bool
     tree_in_info::Bool
@@ -120,6 +125,7 @@ function DPWSolver(;depth::Int=10,
                     alpha_state::Float64=0.5,
                     keep_tree::Bool=false,
                     enable_action_pw::Bool=true,
+                    enable_state_pw::Bool=true,
                     check_repeat_state::Bool=true,
                     check_repeat_action::Bool=true,
                     tree_in_info::Bool=false,
@@ -130,7 +136,7 @@ function DPWSolver(;depth::Int=10,
                     next_action::Any = RandomActionGenerator(rng),
                     default_action::Any = ExceptionRethrow()
                    )
-    DPWSolver(depth, exploration_constant, n_iterations, max_time, k_action, alpha_action, k_state, alpha_state, keep_tree, enable_action_pw, check_repeat_state, check_repeat_action, tree_in_info, rng, estimate_value, init_Q, init_N, next_action, default_action)
+    DPWSolver(depth, exploration_constant, n_iterations, max_time, k_action, alpha_action, k_state, alpha_state, keep_tree, enable_action_pw, enable_state_pw, check_repeat_state, check_repeat_action, tree_in_info, rng, estimate_value, init_Q, init_N, next_action, default_action)
 end
 
 #=

--- a/src/dpw_types.jl
+++ b/src/dpw_types.jl
@@ -89,6 +89,7 @@ Fields:
 
     reset_callback::Function
         Function used to reset/reinitialize the MDP to a given state `s`.
+        Useful when the simulator state is not truly separate from the MDP state.
         `f(mdp, s)` will be called.
         default: `nothing`
 """

--- a/src/dpw_types.jl
+++ b/src/dpw_types.jl
@@ -3,11 +3,11 @@ MCTS solver with DPW
 
 Fields:
 
-    depth::Int64:
+    depth::Int64
         Maximum rollout horizon and tree depth.
         default: 10
 
-    exploration_constant::Float64:
+    exploration_constant::Float64
         Specified how much the solver should explore.
         In the UCB equation, Q + c*sqrt(log(t/N)), c is the exploration constant.
         default: 1.0
@@ -45,11 +45,11 @@ Fields:
         When constructing the tree, check whether a state or action has been seen before (there is a computational cost to maintaining the dictionaries necessary for this)
         default: true
 
-    tree_in_info::Bool:
+    tree_in_info::Bool
         If true, return the tree in the info dict when action_info is called. False by default because it can use a lot of memory if histories are being saved.
         default: false
 
-    rng::AbstractRNG:
+    rng::AbstractRNG
         Random number generator
 
     estimate_value::Any (rollout policy)
@@ -91,7 +91,11 @@ Fields:
         Function used to reset/reinitialize the MDP to a given state `s`.
         Useful when the simulator state is not truly separate from the MDP state.
         `f(mdp, s)` will be called.
-        default: `nothing`
+        default: `(mdp, s)->false` (optimized out)
+
+    show_progress::Bool
+        Show progress bar during simulation.
+        default: false
 """
 mutable struct DPWSolver <: AbstractMCTSSolver
     depth::Int
@@ -114,7 +118,8 @@ mutable struct DPWSolver <: AbstractMCTSSolver
     init_N::Any
     next_action::Any
     default_action::Any
-    reset_callback::Any
+    reset_callback::Function
+    show_progress::Bool
 end
 
 """
@@ -142,9 +147,10 @@ function DPWSolver(;depth::Int=10,
                     init_N::Any = 0,
                     next_action::Any = RandomActionGenerator(rng),
                     default_action::Any = ExceptionRethrow(),
-                    reset_callback::Any = nothing,
+                    reset_callback::Function = (mdp, s)->false,
+                    show_progress::Bool = false,
                    )
-    DPWSolver(depth, exploration_constant, n_iterations, max_time, k_action, alpha_action, k_state, alpha_state, keep_tree, enable_action_pw, enable_state_pw, check_repeat_state, check_repeat_action, tree_in_info, rng, estimate_value, init_Q, init_N, next_action, default_action, reset_callback)
+    DPWSolver(depth, exploration_constant, n_iterations, max_time, k_action, alpha_action, k_state, alpha_state, keep_tree, enable_action_pw, enable_state_pw, check_repeat_state, check_repeat_action, tree_in_info, rng, estimate_value, init_Q, init_N, next_action, default_action, reset_callback, show_progress)
 end
 
 #=

--- a/src/dpw_types.jl
+++ b/src/dpw_types.jl
@@ -86,6 +86,11 @@ Fields:
         If this is a Policy `p`, `action(p, belief)` will be called.
         If it is an object `a`, `default_action(a, pomdp, belief, ex)` will be called, and if this method is not implemented, `a` will be returned directly.
         default: `ExceptionRethrow()`
+
+    reset_callback::Function
+        Function used to reset/reinitialize the MDP to a given state `s`.
+        `f(mdp, s)` will be called.
+        default: `nothing`
 """
 mutable struct DPWSolver <: AbstractMCTSSolver
     depth::Int
@@ -108,6 +113,7 @@ mutable struct DPWSolver <: AbstractMCTSSolver
     init_N::Any
     next_action::Any
     default_action::Any
+    reset_callback::Any
 end
 
 """
@@ -134,9 +140,10 @@ function DPWSolver(;depth::Int=10,
                     init_Q::Any = 0.0,
                     init_N::Any = 0,
                     next_action::Any = RandomActionGenerator(rng),
-                    default_action::Any = ExceptionRethrow()
+                    default_action::Any = ExceptionRethrow(),
+                    reset_callback::Any = nothing,
                    )
-    DPWSolver(depth, exploration_constant, n_iterations, max_time, k_action, alpha_action, k_state, alpha_state, keep_tree, enable_action_pw, enable_state_pw, check_repeat_state, check_repeat_action, tree_in_info, rng, estimate_value, init_Q, init_N, next_action, default_action)
+    DPWSolver(depth, exploration_constant, n_iterations, max_time, k_action, alpha_action, k_state, alpha_state, keep_tree, enable_action_pw, enable_state_pw, check_repeat_state, check_repeat_action, tree_in_info, rng, estimate_value, init_Q, init_N, next_action, default_action, reset_callback)
 end
 
 #=

--- a/src/dpw_types.jl
+++ b/src/dpw_types.jl
@@ -248,12 +248,13 @@ children(n::DPWStateNode) = n.tree.children[n.index]
 n_children(n::DPWStateNode) = length(children(n))
 isroot(n::DPWStateNode) = n.index == 1
 
-mutable struct DPWPlanner{P<:Union{MDP,POMDP}, S, A, SE, NA, RNG} <: AbstractMCTSPlanner{P}
+mutable struct DPWPlanner{P<:Union{MDP,POMDP}, S, A, SE, NA, RCB, RNG} <: AbstractMCTSPlanner{P}
     solver::DPWSolver
     mdp::P
     tree::Union{Nothing, DPWTree{S,A}}
     solved_estimate::SE
     next_action::NA
+    reset_callback::RCB
     rng::RNG
 end
 
@@ -264,11 +265,13 @@ function DPWPlanner(solver::DPWSolver, mdp::P) where P<:Union{POMDP,MDP}
                       actiontype(P),
                       typeof(se),
                       typeof(solver.next_action),
+                      typeof(solver.reset_callback),
                       typeof(solver.rng)}(solver,
                                           mdp,
                                           nothing,
                                           se,
                                           solver.next_action,
+                                          solver.reset_callback,
                                           solver.rng
                      )
 end

--- a/test/dpw_test.jl
+++ b/test/dpw_test.jl
@@ -31,5 +31,5 @@ let
 
     state = GridWorldState(1,1)
 
-    @inferred action_info(policy, state, show_progress=true)
+    @inferred action_info(policy, state)
 end

--- a/test/dpw_test.jl
+++ b/test/dpw_test.jl
@@ -21,4 +21,15 @@ let
     state = GridWorldState(1,1)
 
     a = @inferred action(policy, state)
+
+
+    # ProgressMeter and reset_callback test
+    solver = DPWSolver(n_iterations=n_iter, depth=depth, exploration_constant=ec, reset_callback=(mdp,s)->nothing)
+    mdp = LegacyGridWorld()
+
+    policy = solve(solver, mdp)
+
+    state = GridWorldState(1,1)
+
+    @inferred action_info(policy, state, show_progress=true)
 end


### PR DESCRIPTION
Being an "anytime" algorithm, it's nice to know how long MCTS will take :)
Therefore, I added support for using `@showprogress` from ProgressMeter.jl within `action_info` for the DPWPlanner. Note the progress meter is off by default.

I also added a `reset_callback(mdp, s)` option for the DWPSolver so you can specify a callback function to reset your MDP to a given state. I used these changes for a recent DASC 2020 paper.