### PR TITLE
Relax Colors.jl further to 0.9-0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 CPUTime = "1"
-Colors = "0.11, 0.12"
+Colors = "0.9, 0.10, 0.11, 0.12"
 D3Trees = "0.3"
 POMDPLinter = "0.1"
 POMDPModelTools = "0.3"


### PR DESCRIPTION
I reverted back to Flux@v0.8.3 which uses Colors@v0.9.3 and so I had dependency problems with MCTS (which restricted Colors to 0.10-0.11). 

I tested MCTS with Colors v0.9.3 and they passed.