### PR TITLE
Put search_time in seconds in info

### DIFF
--- a/src/dpw.jl
+++ b/src/dpw.jl
@@ -55,7 +55,7 @@ function POMDPModelTools.action_info(p::DPWPlanner, s; tree_in_info=false)
             end
         end
         p.reset_callback(p.mdp, s) # Optional: leave the MDP in the current state.
-        info[:search_time_us] = (timer() - start_s) * 1e6
+        info[:search_time] = timer() - start_s
         info[:tree_queries] = nquery
         if p.solver.tree_in_info || tree_in_info
             info[:tree] = tree


### PR DESCRIPTION
To make it even more consistent with https://github.com/JuliaPOMDP/POMCPOW.jl/pull/32.

I just found it annoying when switching back and forth between MCTS and POMCPOW that one provides `:search_time` and the other `:search_time_us` in the `info` dict.