### PR TITLE
Tweaked UCB calculation for uniform exploratin of actions in vanilla MCTS

### DIFF
--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -395,30 +395,30 @@ end
 Return the best action node based on the UCB score with exploration constant c
 """
 function best_sanode_UCB(snode::StateNode, c::Float64)
+    if c==0
+        return argmax(q, children(snode))
+    end
+
     best_UCB = -Inf
-    best = first(children(snode))
+    best=first(children(snode))
     sn = total_n(snode)
     for sanode in children(snode)
-	
-	# if sn==0, log(sn) = -Inf. We want to avoid this.
-        # in most cases, if n(sanode)==0, UCB will be Inf, which is desired,
-	# but if sn==1 as well, then we have 0/0, which is NaN
-        if sn == 0 || c == 0
-            UCB = q(sanode)
-        elseif sn == 1 && n(sanode) == 0
-            UCB = Inf
+        # if action was not used, use it. This also handles the case sn==0, 
+        # since sn==0 is possible only when for all available actions n(sanode)==0
+        if n(sanode) == 0
+            return sanode
         else
             UCB = q(sanode) + c*sqrt(log(sn)/n(sanode))
         end
 		
-        if isnan(UCB)
-            @show sn
-            @show n(sanode)
-            @show q(sanode)
-        end
+        # if isnan(UCB)
+        #     @show sn
+        #     @show n(sanode)
+        #     @show q(sanode)
+        # end
 		
-        @assert !isnan(UCB)
-        @assert !isequal(UCB, -Inf)
+        # @assert !isnan(UCB)
+        # @assert !isequal(UCB, -Inf)
 		
         if UCB > best_UCB
             best_UCB = UCB

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -403,8 +403,10 @@ function best_sanode_UCB(snode::StateNode, c::Float64)
 	# if sn==0, log(sn) = -Inf. We want to avoid this.
         # in most cases, if n(sanode)==0, UCB will be Inf, which is desired,
 	# but if sn==1 as well, then we have 0/0, which is NaN
-        if c == 0 || sn == 0 || (sn == 1 && n(sanode) == 0)
+        if sn == 0 || c == 0
             UCB = q(sanode)
+        elseif sn == 1 && n(sanode) == 0
+            UCB = Inf
         else
             UCB = q(sanode) + c*sqrt(log(sn)/n(sanode))
         end

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -400,7 +400,7 @@ function best_sanode_UCB(snode::StateNode, c::Float64)
     end
 
     best_UCB = -Inf
-    best=first(children(snode))
+    best = first(children(snode))
     sn = total_n(snode)
     for sanode in children(snode)
         # if action was not used, use it. This also handles the case sn==0, 


### PR DESCRIPTION
With the current UCB implementation in vanilla MCTS, the first two iterations explore the same action twice:
<img width="279" alt="old" src="https://user-images.githubusercontent.com/1710518/191269174-a9976eee-ea90-44d8-be33-8813e8d7e819.png">[from the example notebook with `n_iter=2`]

This is because the current implementation will set UCB value of an action to the default `q` value when `sn == 1 && n(sanode) == 0` (parent node visited once and action not yet used). This means that if the action used in a state during the first iteration returned a positive reward, it would be picked again in the second iteration since it has a higher value than the unexplored actions. 

I think the usual UCB implementation first explores all available actions in some order before focusing on a specific action. 

With this patch, this seems to be happening:
<img width="300" alt="new" src="https://user-images.githubusercontent.com/1710518/191271411-a241c85b-bcc8-4991-b976-5b34f2877084.png"> [same as previous, but with the patch applied]




