### PR TITLE
Distinguish between `StateNode` creation and lookup

### DIFF
--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -130,14 +130,14 @@ struct StateNode{S,A}
     tree::MCTSTree{S,A}
     id::Int
 end
-StateNode(tree::MCTSTree{S}, s::S) where S = StateNode(tree, tree.state_map[s])
+# StateNode(tree::MCTSTree{S}, s::S) where S = StateNode(tree, tree.state_map[s])
 
 """
     get_state_node(tree::MCTSTree, s)
 
 Return the StateNode in the tree corresponding to s.
 """
-get_state_node(tree::MCTSTree, s) = StateNode(tree, s)
+get_state_node(tree::MCTSTree{S}, s::S) where S = StateNode(tree, tree.state_map[s])
 
 
 # accessors for state nodes
@@ -183,13 +183,13 @@ function clear_tree!(p::MCTSPlanner{S,A}) where {S,A} p.tree = nothing end
 
 Return the StateNode in the tree corresponding to s. If there is no such node, add it using the planner.
 """
-function get_state_node(tree::MCTSTree, s, planner::MCTSPlanner)
-    if haskey(tree.state_map, s)
-        return StateNode(tree, s)
-    else
-        return insert_node!(tree, planner, s)
-    end
-end
+# function get_state_node(tree::MCTSTree, s, planner::MCTSPlanner)
+#     if haskey(tree.state_map, s)
+#         return StateNode(tree, s)
+#     else
+#         return insert_node!(tree, planner, s)
+#     end
+# end
 
 
 # no computation is done in solve - the solver is just given the mdp model that it will work with
@@ -201,7 +201,7 @@ end
 
 function POMDPTools.action_info(p::AbstractMCTSPlanner, s)
     tree = plan!(p, s)
-    best = best_sanode_Q(StateNode(tree, s))
+    best = best_sanode_Q(get_state_node(tree, s))
     return action(best), (tree=tree,)
 end
 
@@ -233,7 +233,7 @@ function POMDPs.value(planner::MCTSPlanner{<:Union{POMDP,MDP}, S, A}, s::S, a::A
 end
 
 function POMDPs.value(tr::MCTSTree{S,A}, s::S, a::A) where {S,A}
-    for san in children(StateNode(tr, s)) # slow search through children
+    for san in children(get_state_node(tr, s)) # slow search through children
         if action(san) == a
             return q(san)
         end

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -130,12 +130,11 @@ struct StateNode{S,A}
     tree::MCTSTree{S,A}
     id::Int
 end
-# StateNode(tree::MCTSTree{S}, s::S) where S = StateNode(tree, tree.state_map[s])
 
 """
     get_state_node(tree::MCTSTree, s)
 
-Return the StateNode in the tree corresponding to s.
+Return the StateNode in the tree corresponding to state s.
 """
 get_state_node(tree::MCTSTree{S}, s::S) where S = StateNode(tree, tree.state_map[s])
 
@@ -177,19 +176,6 @@ end
 Delete existing decision tree.
 """
 function clear_tree!(p::MCTSPlanner{S,A}) where {S,A} p.tree = nothing end
-
-"""
-    get_state_node(tree::MCTSTree, s, planner::MCTSPlanner)
-
-Return the StateNode in the tree corresponding to s. If there is no such node, add it using the planner.
-"""
-# function get_state_node(tree::MCTSTree, s, planner::MCTSPlanner)
-#     if haskey(tree.state_map, s)
-#         return StateNode(tree, s)
-#     else
-#         return insert_node!(tree, planner, s)
-#     end
-# end
 
 
 # no computation is done in solve - the solver is just given the mdp model that it will work with

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -395,30 +395,30 @@ end
 Return the best action node based on the UCB score with exploration constant c
 """
 function best_sanode_UCB(snode::StateNode, c::Float64)
+    if c==0
+        return argmax(q, children(snode))
+    end
+
     best_UCB = -Inf
-    best = first(children(snode))
+    best=first(children(snode))
     sn = total_n(snode)
     for sanode in children(snode)
-	
-	# if sn==0, log(sn) = -Inf. We want to avoid this.
-        # in most cases, if n(sanode)==0, UCB will be Inf, which is desired,
-	# but if sn==1 as well, then we have 0/0, which is NaN
-        if sn == 0 || c == 0
-            UCB = q(sanode)
-        elseif sn == 1 && n(sanode) == 0
-            UCB = Inf
+        # if action was not used, use it. This also handles the case sn==0, 
+        # since sn==0 is possible only when for all available actions n(sanode)==0
+        if n(sanode) == 0
+            return sanode
         else
             UCB = q(sanode) + c*sqrt(log(sn)/n(sanode))
         end
 		
-        if isnan(UCB)
-            @show sn
-            @show n(sanode)
-            @show q(sanode)
-        end
+        # if isnan(UCB)
+        #     @show sn
+        #     @show n(sanode)
+        #     @show q(sanode)
+        # end
 		
-        @assert !isnan(UCB)
-        @assert !isequal(UCB, -Inf)
+        # @assert !isnan(UCB)
+        # @assert !isequal(UCB, -Inf)
 		
         if UCB > best_UCB
             best_UCB = UCB

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -403,8 +403,10 @@ function best_sanode_UCB(snode::StateNode, c::Float64)
 	# if sn==0, log(sn) = -Inf. We want to avoid this.
         # in most cases, if n(sanode)==0, UCB will be Inf, which is desired,
 	# but if sn==1 as well, then we have 0/0, which is NaN
-        if c == 0 || sn == 0 || (sn == 1 && n(sanode) == 0)
+        if sn == 0 || c == 0
             UCB = q(sanode)
+        elseif sn == 1 && n(sanode) == 0
+            UCB = Inf
         else
             UCB = q(sanode) + c*sqrt(log(sn)/n(sanode))
         end

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -400,7 +400,7 @@ function best_sanode_UCB(snode::StateNode, c::Float64)
     end
 
     best_UCB = -Inf
-    best=first(children(snode))
+    best = first(children(snode))
     sn = total_n(snode)
     for sanode in children(snode)
         # if action was not used, use it. This also handles the case sn==0, 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,8 +40,7 @@ state = GWPos(1,1)
     a = @inferred action(policy, state)
 
     tree = policy.tree
-    @test get_state_node(tree, state).id == 1
-    @test get_state_node(tree, state, policy).id == 1
+    @test tree.state_map[state] == 1
 
     clear_tree!(policy)
     @test isnothing(policy.tree)


### PR DESCRIPTION
Addresses https://github.com/JuliaPOMDP/MCTS.jl/issues/63, which in at least one occurrence of the issue was caused by incorrectly dispatching to the `StateNode` constructor in MDP where states were integers.