### PR TITLE
Modify default_action to make function calls that use given mdp/pomdp

### DIFF
--- a/src/default_action.jl
+++ b/src/default_action.jl
@@ -3,9 +3,18 @@ struct ExceptionRethrow end
 default_action(::ExceptionRethrow, mdp, s, ex) = rethrow(ex)
 
 function default_action(f::Function, mdp, s, ex)
-    a = f(s, ex)
-    warn_default(ex, a)
-    return a
+    try
+        a = f(mdp,s,ex)
+        warn_default(ex,a)
+        return a
+    catch e
+        @warn("""
+                Modify the function definition to take three arguments, i.e., f(mdp,s,ex) instead of f(s,ex). The older version will be deprecated soon.""",
+                :MCTS)
+        a = f(s, ex)
+        warn_default(ex, a)
+        return a
+    end
 end
 
 function default_action(p::POMDPs.Policy, mdp, s, ex)

--- a/src/default_action.jl
+++ b/src/default_action.jl
@@ -8,8 +8,7 @@ function default_action(f::Function, mdp, s, ex)
         warn_default(ex,a)
         return a
     catch e
-        @warn("""
-                Modify the function definition to take three arguments, i.e., f(mdp,s,ex) instead of f(s,ex). The older version will be deprecated soon.""",
+        Base.depwarn("""Modify the function definition to take three arguments, i.e., f(mdp,s,ex) instead of f(s,ex). The older version will be deprecated soon.""",
                 :MCTS)
         a = f(s, ex)
         warn_default(ex, a)


### PR DESCRIPTION
Used Base.depwarn to raise the warning message (with force display off)