### PR TITLE
Adding callback function support to MCTS planner

### DIFF
--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -141,14 +141,15 @@ function MCTSPlanner(solver::MCTSSolver, mdp::Union{POMDP,MDP})
     return MCTSPlanner(solver, mdp, tree, se, solver.rng)
 end
 
-# no computation is done in solve - the solver is just given the mdp model that it will work with
-POMDPs.solve(args...) = MCTSPlanner(args...)
-
 
 """
 Delete existing decision tree.
 """
 function clear_tree!(p::MCTSPlanner{S,A}) where {S,A} p.tree = nothing end
+
+
+# no computation is done in solve - the solver is just given the mdp model that it will work with
+POMDPs.solve(solver::MCTSSolver, mdp::Union{POMDP,MDP}) = MCTSPlanner(solver, mdp)
 
 
 @POMDP_require POMDPs.action(policy::AbstractMCTSPlanner, state) begin

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -151,7 +151,6 @@ function clear_tree!(p::MCTSPlanner{S,A}) where {S,A} p.tree = nothing end
 # no computation is done in solve - the solver is just given the mdp model that it will work with
 POMDPs.solve(solver::MCTSSolver, mdp::Union{POMDP,MDP}) = MCTSPlanner(solver, mdp)
 
-
 @POMDP_require POMDPs.action(policy::AbstractMCTSPlanner, state) begin
     @subreq simulate(policy, state, policy.solver.depth)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,6 +162,23 @@ end
     @test_logs (:warn,) (:warn,) (:warn,) action(p, state)
 end
 
+# Example usage of callback function during runtime of tree search.
+# This simple example just prints out the current state of the search
+# tree, but could be used for more sophisticated visualizations or
+# diagnostics.
+@testset "callbacks" begin
+    mdp = SimpleGridWorld()
+    callback_call_count = 0
+    function callback(planner, iteration_index)
+        callback_call_count += 1
+        @info planner.tree
+    end
+    solver = MCTSSolver(n_iterations=10, callback=callback)
+    policy = solve(solver, mdp)
+    a = action(policy, GWPos(1, 1))
+    @test callback_call_count == 10
+end
+
 @nbinclude("../notebooks/Domain_Knowledge_Example.ipynb")
 
 @testset "Discussion 514" begin


### PR DESCRIPTION
This PR adds an optional callback function to run on each MCTS solver iteration, which allows the user to introspect the state of the planner struct while MCTS is running. This is useful for doing live print-outs or visualizations of the MCTS tree while it is expanding, or saving off copies of the MCTS tree every n iterations, for example. The callback function is added as an optional argument to the MCTSPlanner constructor, as to not break existing codebases depending on MCTS.jl.

I have personally found this feature to be very useful to me in developing experimental graphical MCTS.jl visualizations for various MDP projects. I've also found the live introspection of MCTS during runtime to be helpful when developing/debugging MDPs.

Let me know your thoughts, or if there's anything I can do to help improve this PR. Thanks!